### PR TITLE
Reduce scheduled workflow triggers and annotate credit usage

### DIFF
--- a/.github/workflows/ci-deploy-gh-pages-preview.yml
+++ b/.github/workflows/ci-deploy-gh-pages-preview.yml
@@ -2,7 +2,7 @@
 name: Deploy PR previews
 concurrency: preview-${{ github.ref }}
 on:
-  pull_request:
+  pull_request: # need credits
     types:
       - opened
       - reopened

--- a/.github/workflows/ci-deploy-gh-pages.yml
+++ b/.github/workflows/ci-deploy-gh-pages.yml
@@ -2,7 +2,7 @@
 name: Deploy GitHub Pages
 concurrency: preview-deploy-${{ github.ref }}
 on:
-  push:
+  push: # need credits
     branches:
       - main
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
 on:
-  release:
+  release: # need credits
     types: [published]
-  pull_request:
+  pull_request: # need credits
     branches: '**'
-  push:
+  push: # need credits
     branches:
       - develop
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,8 @@
 name: 'Code scanning - action'
 
 on:
-  push:
-  pull_request:
+  push: # need credits
+  pull_request: # need credits
   #schedule:
   #  - cron: '0 13 * * *'
 

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,6 +1,6 @@
 name: 'PR Title Checker'
 on:
-  pull_request_target:
+  pull_request_target: # need credits
     types:
       - opened
       - edited

--- a/.github/workflows/pr-update-description.yml
+++ b/.github/workflows/pr-update-description.yml
@@ -1,7 +1,7 @@
 name: 'Release PR Description'
 
 on:
-  pull_request:
+  pull_request: # need credits
     branches:
       - master
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,7 +1,7 @@
 name: Publish Final Release
 
 on:
-  push:
+  push: # need credits
     branches:
       - master
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,7 +1,8 @@
 name: Release candidate cut
 on:
-  schedule:
-    - cron: '28 0 20 * *' # run at minute 28 to avoid the chance of delay due to high load on GH
+  push: # need credits
+    branches:
+      - main
 jobs:
   new-release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,8 @@
 name: Close inactive issues
 on:
-  schedule:
-    - cron: "0 */6 * * *"
+  push: # need credits
+    branches:
+      - main
 
 jobs:
   close-issues:

--- a/.github/workflows/vulnerabilities-jira-integration.yml
+++ b/.github/workflows/vulnerabilities-jira-integration.yml
@@ -1,8 +1,9 @@
 name: Github vulnerabilities and jira board integration
 
 on:
-  schedule:
-    - cron: '0 1 * * *'
+  push: # need credits
+    branches:
+      - main
       
 jobs:
   IntegrateSecurityVulnerabilities:


### PR DESCRIPTION
## Summary
- replace scheduled triggers with push-only runs for release candidate, vulnerabilities sync, and stale issue workflows
- document credit-sensitive triggers across commit and pull request workflows with a `need credits` comment

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0d3cf941c83319a92f7d2f343da9e